### PR TITLE
Updated to work with flu_ani module

### DIFF
--- a/platemapping/plate_map.py
+++ b/platemapping/plate_map.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import string, math
+from itertools import product
 
 # custom errors 
 class Error(Exception):
@@ -52,7 +53,7 @@ def empty_map(size=96, valid=True):
         empty_df['Type'] = 'empty'
     
     empty_df.drop(labels='Well ID', axis=1, inplace=True)   # remove the redundant 'Well ID' column created from the header_names dict
-    eturn empty_df
+    return empty_df
 
 # PLATE DF GENERATION FROM LONG HAND MAP
 def plate_map(file, size=96, valid=True):
@@ -67,7 +68,7 @@ def plate_map(file, size=96, valid=True):
     :type valid: bool
     :return: Pandas Dataframe of a defined plate map
     """
-     try:   # substitute values w/ new plate map
+    try:   # substitute values w/ new plate map
         data_types = {i[0]: i[1]['dtype'] for i in header_names.items()}   # dictionary with data types
         
         df = pd.read_csv(file, skiprows = 1, dtype = data_types, skipinitialspace = True)   # create the platemap df from csv file
@@ -96,7 +97,7 @@ def plate_map(file, size=96, valid=True):
         return temp
     
     except HeaderError: 
-        print("Headers in csv file are incorrect.\nUse: {}".format(header_names_long))
+        print("Headers in csv file are incorrect.\nUse: {}".format(headers))
     except PlateMapError:
         print("Check your plate map! Incorrect number of wells.")
 
@@ -115,6 +116,7 @@ def short_map(file, size = 96, valid = True):
     try:
         # read in short map 
         df = pd.read_csv(file, skiprows = 1, skipinitialspace = True)
+        headers = [x for x in header_names.keys() if header_names[x]['short_row']]   # list of suitable headers taken from the header_names dictionary
         if list(df.columns) != header_names_short:
             raise HeaderError("Wrong headers!")
             
@@ -153,7 +155,7 @@ def short_map(file, size = 96, valid = True):
         return finalmap
     
     except HeaderError:
-        print("Headers in csv file are incorrect.\nUse: {}".format(header_names_short))
+        print("Headers in csv file are incorrect.\nUse: {}".format(headers))
     except PlateMapError:
         print("Check your plate map! Incorrect number of wells.")
         

--- a/platemapping/plate_map.py
+++ b/platemapping/plate_map.py
@@ -56,7 +56,7 @@ def empty_map(size=96, valid=True, header_type='long'):
     if 'Type' in empty_df.columns:   # set the deafult value of 'Type' column as 'empty'
         empty_df['Type'] = 'empty'
     
-    empty_df.drop(labels='Well ID', axis=1, inplace=True)   # remove the redundant 'Well ID' column created from the header_names dict
+    # empty_df.drop(labels='Well ID', axis=1, inplace=True)   # remove the redundant 'Well ID' column created from the header_names dict
     return empty_df
 
 # PLATE DF GENERATION FROM LONG HAND MAP
@@ -151,12 +151,13 @@ def short_map(file, size=96, valid=True):
         # insert filled df into empty plate map to include empty rows 
         finalmap = empty_map(size=size, valid=valid, header_type='short_row')
         finalmap.update(filleddf)
-        # update data types to prevent future problems
-        finalmap['Column'] = finalmap['Column'].astype(int)
+        # # update data types to prevent future problems
+        # finalmap['Column'] = finalmap['Column'].astype(int)
         # correct typos due to capitalisation and trailing spaces
         finalmap['Type'] = finalmap['Type'].str.lower()
-        finalmap[['Contents', 'Compound', 'Protein', 'Type']] = finalmap[['Contents', 'Compound', 'Protein', 'Type']].stack().str.rstrip().unstack()
-
+        str_cols = [x for x in header_names.keys() if (header_names[x]['dtype'] == str) and 
+                    (header_names[x]['short_row'])]
+        finalmap[str_cols] = finalmap[str_cols].stack(dropna=False).str.rstrip().unstack()
         return finalmap
     
     except HeaderError:

--- a/platemapping/plate_map.py
+++ b/platemapping/plate_map.py
@@ -74,7 +74,7 @@ def plate_map(file, size=96, valid=True):
         df = pd.read_csv(file, skiprows = 1, dtype = data_types, skipinitialspace = True)   # create the platemap df from csv file
         headers = [x for x in header_names.keys() if header_names[x]['long']]   # list of pre-defined headers from header_names dict
         
-        if set(list(df.columns)) != set(headers):   # if headers in imported platemap are ddifferent than pre-defined headers, raise error
+        if set(list(df.columns)) != set(headers):   # if headers in imported platemap are different than pre-defined headers, raise error
             raise HeaderError
 
         df = df.set_index(df['Well ID'])   # set index to Well ID
@@ -117,7 +117,8 @@ def short_map(file, size = 96, valid = True):
         # read in short map 
         df = pd.read_csv(file, skiprows = 1, skipinitialspace = True)
         headers = [x for x in header_names.keys() if header_names[x]['short_row']]   # list of suitable headers taken from the header_names dictionary
-        if list(df.columns) != header_names_short:
+        
+        if set(list(df.columns)) != set(headers):
             raise HeaderError("Wrong headers!")
             
         # generate empty dataframe to append with each duplicated row

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="platemapping", 
-    version="1.0.0",
-    author="Stuart Warriner, Lawrence Collins",
-    author_email="s.l.warriner@leeds.ac.uk, lawrencejordancollins@gmail.com",
+    version="2.0.0",
+    author="Stuart Warriner, Lawrence Collins, Mariusz Las",
+    author_email="s.l.warriner@leeds.ac.uk, lawrencejordancollins@gmail.com, cm18mel@leeds.ac.uk",
     description="Plate map uploading, processing & visualisaion",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Several functions were slightly modified or new features were added so that this module can be used with the fluorescence anisotropy package.

List of changes:
1. In the 'invalidate_cols' function the mechanism of generating all well ids from scratch was replaced with taking them from the platemap index, those are later used to create a list of well ids to be invalidated based on the columns to be invalidated.
2. In 'labelwell' function an option was added to format the number in scientific notation.
3. In 'fontsize' function an option was added to calculate the font size based on a parameter passed (str_len) if the value is to be displayed in scientific notation to avoid calculating it based on the length of original float which gives incorrect result.
4.  In 'visualise' function two parameters were added: 'scinot' and 'str_len' that are passed to labelwell and fontsize functions. Also, in order to generate subplots for all well ids, the function now iterates over a list of tuples (each one containing a row number corresponding to a specified row letter and a column number) used to place the subplot on a grid. There is no need to use the 'Row' and 'Column' columns which are absent in the fluorescence anisotropy platemaps.
5. The header_names_short and header_names_long lists and the data_types dictionary were removed and their information is now sorted in the header_names dictionary.
6. In 'empty_map' function the mechanism of generating the well ids was updated removing the need for 'Row' and 'Column' columns in the platemap.
7. In 'plate_map' function trailing spaces removal mechanism was updated to avoid an error if the platemap csv file has a column with all cells 'NaN'.